### PR TITLE
Increase coverage for some edge cases for future `ruby-3.4`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 * Fix `rubocop-1.64` cop `Style/SuperArguments` warnings.
 * Fix rubocop configuration to be compatible with v3 of `rubocop-rspec`
 * Fix `rubocop-1.65.0` cop `Gemspec/AddRuntimeDependency`
+* Increase coverage for some edge cases for future `ruby-3.4`
+* New optional param for `NumberingProperties#numbering_level_current`
 
 ## 0.37.1 (2023-07-06)
 

--- a/lib/ooxml_parser/common_parser/common_data/paragraph/paragraph_properties/numbering_properties.rb
+++ b/lib/ooxml_parser/common_parser/common_data/paragraph/paragraph_properties/numbering_properties.rb
@@ -46,7 +46,7 @@ module OoxmlParser
       @i_level.value
     end
 
-    # @param [Integer] i-level to find, current one by default
+    # @param [Integer] i_level to find, current one by default
     # @return [AbstractNumbering] level list of current numbering
     def numbering_level_current(i_level = ilvl)
       abstruct_numbering.level_list.each do |current_ilvl|

--- a/lib/ooxml_parser/common_parser/common_data/paragraph/paragraph_properties/numbering_properties.rb
+++ b/lib/ooxml_parser/common_parser/common_data/paragraph/paragraph_properties/numbering_properties.rb
@@ -46,10 +46,11 @@ module OoxmlParser
       @i_level.value
     end
 
+    # @param [Integer] i-level to find, current one by default
     # @return [AbstractNumbering] level list of current numbering
-    def numbering_level_current
+    def numbering_level_current(i_level = ilvl)
       abstruct_numbering.level_list.each do |current_ilvl|
-        return current_ilvl if current_ilvl.ilvl == ilvl
+        return current_ilvl if current_ilvl.ilvl == i_level
       end
       nil
     end

--- a/spec/document/comments_extended_spec.rb
+++ b/spec/document/comments_extended_spec.rb
@@ -3,15 +3,19 @@
 require 'spec_helper'
 
 describe OoxmlParser::CommentExtended do
+  let(:docx) { OoxmlParser::DocxParser.parse_docx('spec/document/comments_extended/comments_extended.docx') }
+
   it 'comments_extended paragraph id' do
-    docx = OoxmlParser::DocxParser.parse_docx('spec/document/comments_extended/comments_extended.docx')
     expect(docx.comments_extended[0].paragraph_id).to eq(1)
     expect(docx.comments_extended[1].paragraph_id).to eq(2)
   end
 
   it 'comments_extended done' do
-    docx = OoxmlParser::DocxParser.parse_docx('spec/document/comments_extended/comments_extended.docx')
     expect(docx.comments_extended[0].done).to be_truthy
     expect(docx.comments_extended[1].done).to be_falsey
+  end
+
+  it 'CommentsExtended#by_id returns nil for unknown id' do
+    expect(docx.comments_extended.by_id(-1)).to be_nil
   end
 end

--- a/spec/document/document_style_spec.rb
+++ b/spec/document/document_style_spec.rb
@@ -13,6 +13,11 @@ describe 'document style' do
     expect(docx.document_styles.last.name).to eq('NewParagraphStyle')
   end
 
+  it 'document_style_by_id for fake name return nil' do
+    docx = OoxmlParser::DocxParser.parse_docx('spec/document/document_style/new_paragraph_style.docx')
+    expect(docx.document_style_by_id(-1000)).to be_nil
+  end
+
   it 'Paragraph Document Visible Style' do
     docx = OoxmlParser::DocxParser.parse_docx('spec/document/document_style/style_visibility.docx')
     expect(docx.document_style_by_name('Heading 8')).to be_visible

--- a/spec/document/document_style_spec.rb
+++ b/spec/document/document_style_spec.rb
@@ -15,7 +15,7 @@ describe 'document style' do
 
   it 'document_style_by_id for fake name return nil' do
     docx = OoxmlParser::DocxParser.parse_docx('spec/document/document_style/new_paragraph_style.docx')
-    expect(docx.document_style_by_id(-1000)).to be_nil
+    expect(docx.document_style_by_id(-1)).to be_nil
   end
 
   it 'Paragraph Document Visible Style' do

--- a/spec/document/elements/paragraph/numbering_spec.rb
+++ b/spec/document/elements/paragraph/numbering_spec.rb
@@ -55,6 +55,11 @@ describe OoxmlParser::Numbering do
     expect(docx.element_by_description.first.numbering.numbering_level_current).to be_a(OoxmlParser::NumberingLevel)
   end
 
+  it 'NumberingProperties#numbering_level_current return nil for unknown level' do
+    docx = OoxmlParser::Parser.parse('spec/document/elements/paragraph/numbering/numbering_suffix.docx')
+    expect(docx.element_by_description.first.numbering.numbering_level_current(-1)).to be_nil
+  end
+
   it 'numbering ilvl is an integer' do
     docx = OoxmlParser::Parser.parse('spec/document/elements/paragraph/numbering/numbering_suffix.docx')
     expect(docx.element_by_description.first.numbering.ilvl).to eq(0)


### PR DESCRIPTION
For some unkonwn reason several tests cases were missing, but only on future `ruby-3.4` dev version

This will fix it