### PR TITLE
Monkeypatch `File::SHARE_DELETE` to be compatible with `truffleruby-24.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 * New optional param for `NumberingProperties#numbering_level_current`
 * Code changes after update to `rubocop-1.68.0`
 
+### Fixes
+
+* Monkey-patch `File::SHARE_DELETE` to be compatible with `truffleruby-24.1.1`
+
 ## 0.37.1 (2023-07-06)
 
 * Add parsing `PivotField#name`

--- a/lib/ooxml_parser.rb
+++ b/lib/ooxml_parser.rb
@@ -1,16 +1,6 @@
 # frozen_string_literal: true
 
-# Monkey patch around
-# https://github.com/oracle/truffleruby/commit/cc76155bf509587e1b2954e9de77c558c7c857f4
-# Remove it as soon as TruffleRuby with fix is released
-if defined?(Truffle)
-  # MonkeyPatch File stdlib class
-  class File < IO
-    # Monkey patch constant missing on TruffleRuby
-    SHARE_DELETE = 0
-  end
-end
-
+require_relative 'truffleruby_patch'
 require_relative 'ooxml_parser/common_parser'
 require_relative 'ooxml_parser/configuration'
 require_relative 'ooxml_parser/helpers/string_helper'

--- a/lib/ooxml_parser.rb
+++ b/lib/ooxml_parser.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+# Monkey patch around
+# https://github.com/oracle/truffleruby/commit/cc76155bf509587e1b2954e9de77c558c7c857f4
+# Remove it as soon as resolved
+if defined?(Truffle)
+  class File < IO
+    SHARE_DELETE   = 0
+  end
+end
+
 require_relative 'ooxml_parser/common_parser'
 require_relative 'ooxml_parser/configuration'
 require_relative 'ooxml_parser/helpers/string_helper'

--- a/lib/ooxml_parser.rb
+++ b/lib/ooxml_parser.rb
@@ -7,7 +7,7 @@ if defined?(Truffle)
   # MonkeyPatch File stdlib class
   class File < IO
     # Monkey patch constant missing on TruffleRuby
-    SHARE_DELETE   = 0
+    SHARE_DELETE = 0
   end
 end
 

--- a/lib/ooxml_parser.rb
+++ b/lib/ooxml_parser.rb
@@ -4,7 +4,9 @@
 # https://github.com/oracle/truffleruby/commit/cc76155bf509587e1b2954e9de77c558c7c857f4
 # Remove it as soon as resolved
 if defined?(Truffle)
+  # MonkeyPatch File stdlib class
   class File < IO
+    # Monkey patch constant missing on TruffleRuby
     SHARE_DELETE   = 0
   end
 end

--- a/lib/ooxml_parser.rb
+++ b/lib/ooxml_parser.rb
@@ -2,7 +2,7 @@
 
 # Monkey patch around
 # https://github.com/oracle/truffleruby/commit/cc76155bf509587e1b2954e9de77c558c7c857f4
-# Remove it as soon as resolved
+# Remove it as soon as TruffleRuby with fix is released
 if defined?(Truffle)
   # MonkeyPatch File stdlib class
   class File < IO

--- a/lib/truffleruby_patch.rb
+++ b/lib/truffleruby_patch.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Monkey patch around
+# https://github.com/oracle/truffleruby/commit/cc76155bf509587e1b2954e9de77c558c7c857f4
+# Remove it as soon as TruffleRuby with fix is released
+if defined?(Truffle)
+  # MonkeyPatch File stdlib class
+  class File < IO
+    # Monkey patch constant missing on TruffleRuby
+    SHARE_DELETE = 0
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ SimpleCov.start do
   # Remove as soon as
   # https://github.com/oracle/truffleruby/commit/cc76155bf509587e1b2954e9de77c558c7c857f4
   # is released
-  add_filter('/lib/ooxml_parser.rb')
+  add_filter('lib/truffleruby_patch.rb')
 end
 
 require 'ooxml_parser'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,10 @@
 require 'simplecov'
 SimpleCov.start do
   add_filter('/spec/')
+  # Remove as soon as
+  # https://github.com/oracle/truffleruby/commit/cc76155bf509587e1b2954e9de77c558c7c857f4
+  # is released
+  add_filter('/lib/ooxml_parser.rb')
 end
 
 require 'ooxml_parser'


### PR DESCRIPTION
Known issue:

https://github.com/oracle/truffleruby/issues/3745

This fix will fix nighly failures:

https://github.com/ONLYOFFICE-QA/ooxml_parser/actions/runs/12424963685/job/34705173068